### PR TITLE
modernization cleanups

### DIFF
--- a/CBSE.py
+++ b/CBSE.py
@@ -70,9 +70,6 @@ class Message:
     def get_num_args(self):
         return len(self.args)
 
-    def get_enum_name(self):
-        return 'MSG_' + self.name.upper()
-
     def get_handler_name(self):
             return 'Handle' + self.name
 

--- a/templates/Backend.cpp
+++ b/templates/Backend.cpp
@@ -63,10 +63,6 @@ Entity::Entity(const MessageHandler *messageHandlers, const int* componentOffset
 
 {}
 
-// Base entity deconstructor.
-Entity::~Entity()
-{}
-
 // Base entity's message dispatcher.
 bool Entity::SendMessage(int msg, const void* data) {
 	MessageHandler handler = messageHandlers[msg];
@@ -148,7 +144,7 @@ bool Entity::SendMessage(int msg, const void* data) {
 	{% for message in entity.get_messages_to_handle() %}
 
 		// {{entity.get_type_name()}}'s {{message.get_name()}} message dispatcher.
-		void {{entity.get_message_handler_name(message)}}(Entity* _entity, const void* {% if message.get_num_args() > 0 %} _data{% endif %}) {
+		void {{entity.get_message_handler_name(message)}}(Entity* _entity, const void*{% if message.get_num_args() > 0 %} _data{% endif %}) {
 			//* Cast the entity to the correct type (receive an Entity*)
 			{{entity.get_type_name()}}* entity = ({{entity.get_type_name()}}*) _entity;
 			{% if message.get_num_args() == 0 %}
@@ -202,11 +198,6 @@ bool Entity::SendMessage(int msg, const void* data) {
 				, {{required.get_variable_name()}}
 			{%- endfor -%})
 		{% endfor %}
-	{}
-
-	// {{entity.get_type_name()}}'s deconstructor.
-	//* Destroys all the components in reverse order.
-	{{entity.get_type_name()}}::~{{entity.get_type_name()}}()
 	{}
 {% endfor %}
 

--- a/templates/Backend.cpp
+++ b/templates/Backend.cpp
@@ -64,8 +64,8 @@ Entity::Entity(const MessageHandler *messageHandlers, const int* componentOffset
 {}
 
 // Base entity's message dispatcher.
-bool Entity::SendMessage(int msg, const void* data) {
-	MessageHandler handler = messageHandlers[msg];
+bool Entity::SendMessage(EntityMessage msg, const void* data) {
+	MessageHandler handler = messageHandlers[static_cast<int>(msg)];
 	if (handler) {
 		handler(this, data);
 		return true;
@@ -80,10 +80,10 @@ bool Entity::SendMessage(int msg, const void* data) {
 
 	bool Entity::{{message.name}}({{message.get_function_args()}}) {
 		{% if message.get_num_args() == 0 %}
-			return SendMessage({{message.get_enum_name()}}, nullptr);
+			return SendMessage(EntityMessage::{{message.get_name()}}, nullptr);
 		{% else %}
 			{{message.get_tuple_type()}} data({{message.get_args_names()}});
-			return SendMessage({{message.get_enum_name()}}, &data);
+			return SendMessage(EntityMessage::{{message.get_name()}}, &data);
 		{% endif %}
 	}
 {% endfor %}

--- a/templates/Backend.cpp
+++ b/templates/Backend.cpp
@@ -146,7 +146,7 @@ bool Entity::SendMessage(EntityMessage msg, const void* data) {
 		// {{entity.get_type_name()}}'s {{message.get_name()}} message dispatcher.
 		void {{entity.get_message_handler_name(message)}}(Entity* _entity, const void*{% if message.get_num_args() > 0 %} _data{% endif %}) {
 			//* Cast the entity to the correct type (receive an Entity*)
-			{{entity.get_type_name()}}* entity = ({{entity.get_type_name()}}*) _entity;
+			auto* entity = static_cast<{{entity.get_type_name()}}*>(_entity);
 			{% if message.get_num_args() == 0 %}
 				{% for component in entity.get_components() %}
 					{% if message in component.get_messages_to_handle() %}
@@ -156,7 +156,7 @@ bool Entity::SendMessage(EntityMessage msg, const void* data) {
 				{% endfor %}
 			{% else %}
 				//* Cast the message content to the right type (received a const void*)
-				const {{message.get_tuple_type()}}* data = (const {{message.get_tuple_type()}}*) _data;
+				const auto* data = static_cast<const {{message.get_tuple_type()}}*>(_data);
 				{% for component in entity.get_components() %}
 					{% if message in component.get_messages_to_handle() %}
 						entity->{{component.get_variable_name()}}.{{message.get_handler_name()}}({{message.get_unpacked_tuple_args('*data')}});

--- a/templates/Backend.h
+++ b/templates/Backend.h
@@ -86,7 +86,7 @@ class Entity;
 {% endfor %}
 
 /** Message handler declaration. */
-typedef void (*MessageHandler)(Entity*, const void*);
+using MessageHandler = void (*)(Entity*, const void* /*_data*/);
 
 // //////////////////// //
 // Component priorities //
@@ -125,7 +125,7 @@ class Entity {
 		/**
 		 * @brief Base entity deconstructor.
 		 */
-		virtual ~Entity();
+		virtual ~Entity() = default;
 
 		// /////////////// //
 		// Message helpers //

--- a/templates/Backend.h
+++ b/templates/Backend.h
@@ -69,9 +69,9 @@
 // /////////// //
 
 //* An enum of message IDs used to index the vtable.
-enum {
+enum class EntityMessage {
 	{% for message in messages %}
-		{{message.get_enum_name()}},
+		{{message.get_name()}},
 	{% endfor %}
 };
 
@@ -172,7 +172,7 @@ class Entity {
 		 * @brief Generic message dispatcher.
 		 * @note Should not be called directly, use message helpers instead.
 		 */
-		bool SendMessage(int msg, const void* data);
+		bool SendMessage(EntityMessage msg, const void* data);
 
     public:
 		// ///////////////////// //

--- a/templates/Entities.h
+++ b/templates/Entities.h
@@ -72,7 +72,7 @@
 			{{entity.get_type_name()}}(Params params);
 
 			/** Default destructor of {{entity.get_type_name()}}. */
-			virtual ~{{entity.get_type_name()}}();
+			virtual ~{{entity.get_type_name()}}() = default;
 
 			{% for component in entity.get_components() %}
 				{{component.get_type_name()}} {{component.get_variable_name()}}; /**< {{entity.get_type_name()}}'s {{component.get_type_name()}} instance. */


### PR DESCRIPTION
Uses default constructors, `using` instead of `typedef` and makes the Entity message enum typesafe to guard against clashes with MSG_* macros (e.g. socket.h already uses that). Replaces c-style casts with static_casts for compile-time over runtime checking.