### PR TITLE
Fix yaml-string remapping from quoted strings to native strings.

### DIFF
--- a/CBSE.py
+++ b/CBSE.py
@@ -37,14 +37,6 @@ import argparse, sys
 import os.path
 import re
 
-# A data container created from the YAML 'plain' tag
-class Plain:
-    def __init__(self, data):
-        self.data = data
-
-    def value(self):
-        return self.data
-
 class CommonAttribute:
     def __init__(self, name, typ):
         self.name = name
@@ -316,15 +308,9 @@ class Entity:
 
 def convert_params(params):
     # Convert defaults to strings that C++ understands.
-    # TODO: Add support for char and others
-    # WORKAROUND: Can specify char x via !!python/object/apply:builtins.ord ['x']
     for param, value in params.items():
         if type(value) == bool:
             value = str(value).lower()
-        elif type(value) == str:
-            value = '"' + value + '"'
-        elif isinstance(value, Plain):
-            value = value.value()
         elif value is None:
             pass
         else:
@@ -543,14 +529,9 @@ class OrderedLoader(yaml.Loader):
         loader.flatten_mapping(node)
         return OrderedDict(loader.construct_pairs(node))
 
-    @staticmethod
-    def MakePlain(loader, node):
-        return Plain(node.value)
-
     def __init__(self, stream):
         yaml.Loader.__init__(self, stream)
         self.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, self.OrderedMapping)
-        self.add_constructor(u'tag:yaml.org,2002:plain', self.MakePlain)
 
 
 if __name__ == '__main__':

--- a/def.yaml
+++ b/def.yaml
@@ -77,16 +77,16 @@ components:
             anInt:     int
             aBool:     bool
         defaults:
-            aConstant: !!plain __LINE__
-            aString:   "I am a string"
+            aConstant: __LINE__
+            aString:   '"I am a string"'
             anInt:     23
             aBool:     true
 
     TypeTest2:
         requires:
             TypeTest1:
-                aConstant: !!plain __LINE__
-                aString:   "I am a string"
+                aConstant: __LINE__
+                aString:   '"I am a string literal"'
                 anInt:     23
                 aBool:     true
 
@@ -118,8 +118,10 @@ entities:
     TypeTest3:
         components:
             TypeTest1:
-                aConstant: !!plain __LINE__
-                aString:   "I am a string"
+                aConstant: __LINE__
+                someCode:  '&*yaml::conflicting::symbols[0]'
+                aString:   '"I am a string literal"'
+                aChar:     "'a'"
                 anInt:     23
                 aBool:     true
 


### PR DESCRIPTION
Besides being less verbose than depending on a custom tag for native strings (i.e. python strings, which are directly used in the templates),
it should fix an issue where referenced yaml blocks lead to overquoted strings in the templates like `""""""""""SomeConstant""""""""""`

Quoted strings for c++ string literals can be set as quotes within forced yaml strings i.e. `'"literal"'` or `"\"literal\""`

In a similar way chars can now be specified, just with different quotes on the inside: `"'c'"` or `'\'c\''`

I left the custom yaml loader in place in case we want to add other tags in the future.